### PR TITLE
Add failing test case for loader query strings

### DIFF
--- a/test/Config.spec.js
+++ b/test/Config.spec.js
@@ -67,6 +67,38 @@ describe('Config', () => {
                 bar: ['bar1', 'bar2']
             });
         });
+
+        it('should preserve arrays of objects in loader queries', () => {
+            config.merge({
+                module: {
+                    loaders: [{
+                        test: 'foo',
+                        loader: 'bar?' + JSON.stringify({
+                            foo: [
+                                { x: 1 },
+                                { y: 2 },
+                                { z: 3 }
+                            ]
+                        })
+                    }]
+                }
+            });
+
+            expect(config.toObject()).toEqual({
+                module: {
+                    loaders: [{
+                        test: 'foo',
+                        loader: 'bar?' + JSON.stringify({
+                            foo: [
+                                { x: 1 },
+                                { y: 2 },
+                                { z: 3 }
+                            ]
+                        })
+                    }]
+                }
+            });
+        });
     });
 
     describe('#extend()', () => {


### PR DESCRIPTION
Failing test case for #45.

(I also find it suspect that having a loader query option that's an array e.g. `[1, 2]` will trigger Array merging behavior and just set that query option to `2`.)