### PR TITLE
fix(ConfigPatternCache): fixes an issue when `#eval(...)` interprets `JSON.stringify`-values as template properties

### DIFF
--- a/src/ConfigPatternCache.js
+++ b/src/ConfigPatternCache.js
@@ -6,7 +6,7 @@ import {
  * @private
  * @type {RegExp}
  */
-const DEFAULT_INTERPOLATE = /\[([\s\S]+?)]/g;
+const DEFAULT_INTERPOLATE = /\[([\w\s]+?)]/g;
 
 /**
  * @private
@@ -21,7 +21,7 @@ const INTERPOLATE = new WeakMap();
 class ConfigPatternCache extends Map {
     /**
      * @constructor
-     * @param {RegExp} [interpolate=/\[([\s\S]+?)]/g]
+     * @param {RegExp} [interpolate=/\[([\w\s]+?)]/g]
      */
     constructor(interpolate = DEFAULT_INTERPOLATE) {
         super();
@@ -42,7 +42,7 @@ class ConfigPatternCache extends Map {
      *   patternCache
      * } from 'webpack-config';
      *
-     * patternCache.interpolate = /{([\s\S]+?)}/g;
+     * patternCache.interpolate = /{([\w\s]+?)}/g;
      * @param {RegExp} value
      */
     set interpolate(value) {

--- a/test/ConfigPatternCache.spec.js
+++ b/test/ConfigPatternCache.spec.js
@@ -40,15 +40,31 @@ describe('ConfigPatternCache', () => {
 
     describe('#eval()', () => {
         it('should replace `[foo]` with `bar`', () => {
-            const value = patternCache.eval('[foo]-[foo]', {
+            expect(patternCache.eval('[foo]-[foo]', {
                 foo: 'bar'
-            });
+            })).toEqual('bar-bar');
 
-            expect(value).toEqual('bar-bar');
+            expect(patternCache.eval('[ foo ]-[ foo ]', {
+                foo: 'bar'
+            })).toEqual('bar-bar');
         });
 
-        it('should replace `{foo}` with `bar`', () => {
-            patternCache.interpolate = /{([\s\S]+?)}/g;
+        it('should not replace `JSON.stringify`-strings', () => {
+            const str = JSON.stringify({
+                foo: [
+                    { x: 1 },
+                    { y: 2 },
+                    { z: 3 }
+                ]
+            });
+
+            expect(patternCache.eval(str, {})).toEqual(str);
+        });
+    });
+
+    describe('#interpolate', () => {
+        it('should replace `{foo}` with `bar` using custom `interpolate`', () => {
+            patternCache.interpolate = /{([\w\s]+?)}/g;
 
             const value = patternCache.eval('{foo}-{foo}', {
                 foo: 'bar'


### PR DESCRIPTION
This fixes issue #45, and closes PR #46.